### PR TITLE
Update URL to packages.chef.io

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ export CHEF_CACHE_DIR=${WERCKER_CACHE_DIR}/wercker/chefdk
 
 mkdir -p "$CHEF_CACHE_DIR"
 if [ ! -f "${CHEF_CACHE_DIR}/${CHEF_DEB}" ]; then
-    wget --no-check-certificate -P "$CHEF_CACHE_DIR" "https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/${CHEF_DEB}"
+    wget --no-check-certificate -P "$CHEF_CACHE_DIR" "https://packages.chef.io/stable/ubuntu/12.04/${CHEF_DEB}"
 fi
 sudo dpkg -i "${CHEF_CACHE_DIR}/${CHEF_DEB}"
 

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: chefdk
-version: 0.0.4
+version: 0.0.5
 description: Wercker step for installing Chef Development Kit
 kyewords:
   - chef


### PR DESCRIPTION
Chef.io has moved their url to packages.chef.io.

ref: https://blog.chef.io/2016/03/16/weve-moved-our-software-distribution-to-packages-chef-io/
